### PR TITLE
Fixed shebang, check filename, exploitdb default path fur recent kali…

### DIFF
--- a/auto_priv_exploit.sh
+++ b/auto_priv_exploit.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 usage(){
 	echo "[*] Usage: $0 VERSION_OF_KERNEL";
@@ -8,7 +8,7 @@ usage(){
 
 download(){
 
-	base="/usr/share/exploitdb/platforms"
+	base="/usr/share/exploitdb/exploits/"
 	echo "[*] The base directory is $base"
 
 	[ -d "linux_$version" ] || mkdir linux_$version # make directory if not exist
@@ -35,15 +35,16 @@ download(){
 compile(){
 	for file in $file_list; do
 		file_extension=$(echo $file | cut -d '.' -f 2) # extract the file extension
-		file_name=$(echo $file | cut -d '/' -f 4) #extrac the file name
+		file_name=$(echo $file | cut -d '/' -f 3) #extrac the file name
 		if [ "$file_extension" == "c" ]; then
-			gcc linux_$version/$file_name -o linux_$version/"$file_name.exe" 2>/dev/null
+			# gcc linux_$version/$file_name -o linux_$version/"$file_name.exe" 2>/dev/null
+			gcc linux_$version/$file_name -o linux_$version/"$file_name.exe"
 		fi
 	done
 }
 
 version=$1
-file_list=$(searchsploit $version linux| grep local | grep -i privilege | cut -d '|' -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+file_list=$(searchsploit --colour $version linux| grep local | grep -i privilege | cut -d '|' -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 
 py_file_count=0
 txt_file_count=0
@@ -54,7 +55,7 @@ pl_file_count=0
 main(){
 	echo -e "[*] Possible Exploit\n"
     searchsploit $version linux | grep local | grep -i privilege
-    if [ -z $file_list ]; then
+    if [ -z "$file_list" ]; then
         echo "No possible exploit. Please use another version."
         exit 1
     fi
@@ -91,7 +92,7 @@ main(){
 	echo "TXT file in $PWD/linux_$version has $txt_file_count files"
     echo ""
 	echo "[*] Successfully Compiled $exe_file_count executable located in linux_$version"
-	
+
 }
 
 


### PR DESCRIPTION
This PR fixes some issues, some of them related with the new kali version: 
- Fixed shebang /bin/bash (for zsh shell it gives errors) 
- Fixed -z check in file_name array variable (double quotes added) 
- Fixed the exploitdb default path (for current kali version (2021) it is `/usr/share/exploitdb/exploits/` instead of `/usr/share/exploitdb/platforms`. 
- Fixed file_name in compile step. 